### PR TITLE
CI: Re-trigger workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,8 +160,7 @@ exclude = [
 ]
 
 [tool.setuptools]
-packages = []
 
 [tool.setuptools.packages.find]
-exclude = ["bears*","bears1*", "images*", "tests*", "venv*", "env*"]
-namespaces = false 
+exclude = ["bears*", "images*", "tests*", "venv*", "env*"]
+namespaces = false


### PR DESCRIPTION
Creating an empty commit to force a new CI run after remote changes.